### PR TITLE
Fix: Configure server and dependencies for Ollama web UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,12 @@
   "version": "1.0.0",
   "description": "UI for Ollama",
   "scripts": {
-    "start": "serve public"
+    "start": "node server.js"
   },
   "dependencies": {
-    "serve": "^14.0.0"
+    "serve": "^14.0.0",
+    "express": "^5.1.0",
+    "cors": "^2.8.5",
+    "axios": "^1.9.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const port = 3000;
 app.use(cors());
 
 // Serve static files
-app.use(express.static('.'));
+app.use(express.static('public'));
 
 // Log all incoming requests
 app.use((req, res, next) => {


### PR DESCRIPTION
This commit addresses the issue of the web UI not being able to connect to the Ollama backend by:

1.  Modifying `server.js` to correctly serve static files from the `public` directory using `express.static('public')`.
2.  Updating the `scripts.start` in `package.json` to `node server.js`, ensuring the Express server (which includes the Ollama proxy) is run on startup.
3.  Adding missing dependencies (`express`, `cors`, `axios`) to `package.json` required by `server.js`.

With these changes, you can now run `npm install` and then `npm start` to launch the web UI, which will proxy requests to your local Ollama instance. Instructions for setup and model selection have also been prepared.